### PR TITLE
Minor additions for cross-platform dev

### DIFF
--- a/GYM/evaluate_policy.py
+++ b/GYM/evaluate_policy.py
@@ -5,7 +5,15 @@ from gymnasium import register
 from ray.rllib import TFPolicy, TorchPolicy
 from ray.rllib.models import ModelCatalog
 from custom_models import *
-backend="tf"
+
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "backend", type=str, default="torch", help="Specify the used ML framework (torch or tf)"
+)
+args = parser.parse_args()
+backend = args.backend
 register(id='PymunkPole-v0',entry_point='PymunkPole.PymunkPoleEnv:PymunkCartPoleEnv')
 ModelCatalog.register_custom_model("reg_model",
                                    RegularizedTorchModel if backend == "torch" else RegularizedTFModel)

--- a/GYM/evaluate_trainer.py
+++ b/GYM/evaluate_trainer.py
@@ -6,7 +6,15 @@ from gymnasium import register
 from ray.rllib.algorithms import Algorithm
 from ray.rllib.models import ModelCatalog
 from custom_models import RegularizedTFModel, RegularizedTorchModel
-backend="torch"
+
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "backend", type=str, default="torch", help="Specify the used ML framework (torch or tf)"
+)
+args = parser.parse_args()
+backend = args.backend
 register(id='PymunkPole-v0',entry_point='PymunkPole.PymunkPoleEnv:PymunkCartPoleEnv')
 ray.init()
 ModelCatalog.register_custom_model("reg_model",

--- a/Unity/train/rllib/requirements.txt
+++ b/Unity/train/rllib/requirements.txt
@@ -1,0 +1,7 @@
+wheel
+nvidia-pyindex
+onnx
+torch
+rllib
+protobuf==3.20.*
+numpy==1.23.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+ray[rllib]
+torch
+gym
+pygame
+pymunk


### PR DESCRIPTION
I had some  issues with running these examples on Linux, so I made some minor changes.
* the `keyboard` module requires sudo permissions on Linux, so I replaced it with a KeyboardInterrupt.
* unity server `.exe` was hardcoded, so I added a program argument for it.
* added basic `requirements.txt` files for easier installation of Python dependencies
  * including some downgraded versions of packages, because of compatibility issues